### PR TITLE
bugfix/APNS handling code called on wrong thread

### DIFF
--- a/Pod/Classes/SEGAppboyIntegration.m
+++ b/Pod/Classes/SEGAppboyIntegration.m
@@ -287,10 +287,12 @@
     // The existence of a push payload saved on the factory indicates that the push was received when
     // Appboy was not initialized yet, and thus the push was received in the inactive state.
     if ([[Appboy sharedInstance] respondsToSelector:@selector(handleRemotePushNotification:withIdentifier:completionHandler:applicationState:)]) {
-      [[Appboy sharedInstance] handleRemotePushNotification:pushDictionary
-                                             withIdentifier:identifier
-                                          completionHandler:nil
-                                           applicationState:UIApplicationStateInactive];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[Appboy sharedInstance] handleRemotePushNotification:pushDictionary
+                                                   withIdentifier:identifier
+                                                completionHandler:nil
+                                                 applicationState:UIApplicationStateInactive];
+        });
     }
     [[SEGAppboyIntegrationFactory instance] saveRemoteNotification:nil];
     return YES;


### PR DESCRIPTION
Appboy's APNS handling code is currently being called on a background thread when Braze documentation states it needs to be called on the main thread. 

Due to this, there is currently an issue where In-App Messages cannot be tested, as the Braze Dashboard sends push notifications you must tap which would cause the UI presentation.